### PR TITLE
Defined a cached iterator

### DIFF
--- a/Source/Core/Helper.cs
+++ b/Source/Core/Helper.cs
@@ -19,5 +19,30 @@ namespace Pamola
             if (source==null) throw new ArgumentNullException(parameterName);            
             return source;
         }
+
+        public static IEnumerable<T> ToCachedEnumerable<T>(
+            this IEnumerable<T> source
+        )
+        {
+            var cache = new List<T>();
+            return source.GetEnumerator().ToCachedEnumerableHelper(cache);
+        }
+
+        private static IEnumerable<T> ToCachedEnumerableHelper<T>(
+            this IEnumerator<T> source,
+            IList<T> cache
+        )
+        {
+            foreach (var t in cache)
+            {
+                yield return t;
+            }
+
+            while(source.MoveNext())
+            {
+                cache.Add(source.Current);
+                yield return source.Current;
+            }
+        }
     }
 }

--- a/Tests/Core/Helper.UT.cs
+++ b/Tests/Core/Helper.UT.cs
@@ -22,5 +22,42 @@ namespace Pamola.UT
             object obj = new object();
             Assert.Equal(obj, obj.ThrowOnNull());
         }
+
+        [Fact]
+        public void ToCacheEnumerableHitsOncePerExpansion()
+        {
+            var hitCount = 0;
+            var cachedEnumerable = Enumerable.Range(0,10).Select(
+                i => 
+                {
+                    hitCount++;
+                    return i;
+                }
+            ).ToCachedEnumerable();
+
+            var firstItem = cachedEnumerable.First();
+            var firstItem2 = cachedEnumerable.First();
+
+            Assert.Equal(hitCount, 1);
+            Assert.Equal(firstItem, firstItem2);
+        }
+
+        [Fact]
+        public void ToCachedEnumerableHitsEqualExpansionSize()
+        {
+            var hitCount = 0;
+            var cachedEnumerable = Enumerable.Range(0,10).Select(
+                i => 
+                {
+                    hitCount++;
+                    return i;
+                }
+            ).ToCachedEnumerable();
+
+            var first4Items = cachedEnumerable.Take(4).ToList();
+            var first5Items = cachedEnumerable.Take(5).ToList();
+            Assert.Equal(hitCount, 5);
+            Assert.Equal(first4Items, first5Items.Take(4));
+        }
     }
 }


### PR DESCRIPTION
This ensures that a `IEnumerable` is called only once.
It'll be useful when each item on a transient system will require a full system solve, the cached `IEnumerable` will call the generator when needed only once and store the returned values in a list for further calls